### PR TITLE
New `src/iter` directory

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -65,6 +65,18 @@ module.exports = {
       }
     },
     {
+      name: 'not-to-iter-files',
+      comment:
+        "(FA) iterator function should only be accessed via the `src/iter/index.ts` file.",
+      severity: 'error',
+      from: {
+        path: '^(src/(?!iter/))'
+      },
+      to: {
+        path: '^(src/iter/(?!index))'
+      }
+    },
+    {
       name: 'base-to-JS',
       comment:
         "Files from the base library should not reference the JS-specific part.",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,8 @@ refa/
 |-- scripts/
 |   `-- ...
 |-- src/
+|   |-- iter/
+|   |   `-- ...
 |   |-- js/
 |   |   `-- ...
 |   `-- ...
@@ -58,6 +60,18 @@ The most important files are:
 1. `finite-automaton.ts` defines interfaces all concrete FA implementations use.
 1. `{dfa,nfa}.ts` define the concrete implementations of an NFA and DFA.
 1. `words.ts` includes function to convert from JS strings to number arrays and vise versa among others.
+
+#### `src/iter`
+
+This directory contains functions that consume and produce graph iterators. Graph iterators are one of refa's core concepts and allow us to implement different algorithms independently from one specific graph representation.
+
+When importing those functions from outside `src/iter`, it must be done via `src/iter/index.ts`. It's recommended to import all functions like this:
+
+```js
+import * as Iter from "./iter";
+```
+
+From inside `src/iter`, functions MUST be imported directly from the file they are defined in.
 
 #### `src/js`
 

--- a/src/finite-automaton.ts
+++ b/src/finite-automaton.ts
@@ -73,7 +73,7 @@ export interface ToRegexOptions {
 }
 
 /**
- * An iterator over all states of an FA with final states.
+ * A graph iterator over all states of an FA with final states.
  */
 export interface FAIterator<S, O = Iterable<S>> {
 	readonly initial: S;

--- a/src/iter/index.ts
+++ b/src/iter/index.ts
@@ -1,0 +1,5 @@
+export * from "./intersection";
+export * from "./iterator";
+export * from "./to-regex";
+export * from "./to-string";
+export * from "./word-sets";

--- a/src/iter/intersection.ts
+++ b/src/iter/intersection.ts
@@ -1,6 +1,6 @@
-import { CharSet } from "./char-set";
-import { faEnsurePureOut } from "./fa-iterator";
-import { FAIterator, IntersectionOptions, TooManyNodesError } from "./finite-automaton";
+import { CharSet } from "../char-set";
+import { ensurePureOut } from "./iterator";
+import { FAIterator, IntersectionOptions, TooManyNodesError } from "../finite-automaton";
 
 /**
  * An FA builder has the responsibility of constructing a finite automata.
@@ -50,14 +50,14 @@ export class TransitionMapBuilder implements FABuilder<TransitionMap, CharSet> {
  * @param right
  * @param options
  */
-export function lazyIntersection<S, L, R>(
+export function intersection<S, L, R>(
 	builder: FABuilder<S, CharSet>,
 	left: FAIterator<L, ReadonlyMap<L, CharSet>>,
 	right: FAIterator<R, ReadonlyMap<R, CharSet>>,
 	options: undefined | Readonly<IntersectionOptions>
 ): FAIterator<S, S> {
-	left = faEnsurePureOut(left);
-	right = faEnsurePureOut(right);
+	left = ensurePureOut(left);
+	right = ensurePureOut(right);
 
 	const maxNodes = options?.maxNodes ?? Infinity;
 

--- a/src/iter/to-regex.ts
+++ b/src/iter/to-regex.ts
@@ -10,10 +10,10 @@ import {
 	Element,
 	Assertion,
 	visitAst,
-} from "./ast";
-import { CharSet } from "./char-set";
-import { cachedFunc, DFS, firstOf, minOf, assertNever, filterMut } from "./util";
-import { ToRegexOptions, TooManyNodesError, FAIterator } from "./finite-automaton";
+} from "../ast";
+import { CharSet } from "../char-set";
+import { cachedFunc, DFS, firstOf, minOf, assertNever, filterMut } from "../util";
+import { ToRegexOptions, TooManyNodesError, FAIterator } from "../finite-automaton";
 
 type RegexFANodeTransition = Simple<Concatenation | Alternation | CharacterClass | Quantifier>;
 interface RegexFANode {
@@ -1175,7 +1175,7 @@ function optimize(expr: Simple<Expression>): boolean {
 	return optimized;
 }
 
-export function faToRegex<T>(
+export function toRegex<T>(
 	iter: FAIterator<T, Iterable<[T, CharSet]>>,
 	options?: Readonly<ToRegexOptions>
 ): Simple<Expression> {

--- a/src/iter/to-string.ts
+++ b/src/iter/to-string.ts
@@ -1,0 +1,69 @@
+import { FAIterator } from "../finite-automaton";
+import { cacheOut, iterateStates, mapOut, mapOutIter } from "./iterator";
+
+/**
+ * Returns a human readable string representation of the given FA. The FA has to have exactly one initial state.
+ *
+ * All states will be labeled with numbers. The initial state will **always** has the number 0. Each state will be
+ * mapped to its outgoing states. The outgoing states may contain duplicates and are sorted alphabetically by their
+ * transition string. The number of states will be surrounded by brackets - square brackets for final states and round
+ * brackets for non-final states.
+ *
+ * A conversion function for the transitions may optionally be given. If no transition function is given, the native
+ * `String` function will be used.
+ *
+ * ---
+ *
+ * Example output for an NFA of `a*d|bb*`
+ *
+ * ```txt
+ * (0) -> (1) : 'a'
+ *     -> [2] : 'b'
+ *     -> [3] : 'd'
+ *
+ * (1) -> [3] : 'd'
+ *
+ * [2] -> [2] : 'b'
+ *
+ * [3] -> none
+ * ```
+ */
+export function toString<S, T>(iter: FAIterator<S, Iterable<[S, T]>>, toString: (value: T) => string = String): string {
+	const stableIter = cacheOut(
+		mapOut(iter, out => {
+			return [...out]
+				.map<[S, string]>(([k, v]) => [k, toString(v)])
+				.sort(([, a], [, b]) => a.localeCompare(b));
+		})
+	);
+
+	// get all states
+	const states: S[] = [...iterateStates(mapOutIter(stableIter, ([s]) => s))];
+
+	const index = new Map<S, number>(states.map((s, i) => [s, i]));
+	const indexOf = (state: S): number => {
+		return index.get(state)!;
+	};
+	const labelOf = (state: S): string => {
+		const index = indexOf(state);
+		return stableIter.isFinal(state) ? `[${index}]` : `(${index})`;
+	};
+
+	return states
+		.map(state => {
+			const label = labelOf(state);
+			const out = stableIter.getOut(state).sort(([s1], [s2]) => indexOf(s1) - indexOf(s2));
+
+			if (out.length === 0) {
+				return `${label} -> none`;
+			} else {
+				const spaces = " ".repeat(label.length);
+				return out
+					.map(([s, t], i) => {
+						return `${i ? spaces : label} -> ${labelOf(s)} : ${t}`;
+					})
+					.join("\n");
+			}
+		})
+		.join("\n\n");
+}

--- a/src/words.ts
+++ b/src/words.ts
@@ -1,4 +1,5 @@
 import { CharRange, CharSet } from "./char-set";
+import { wordSetToWords as wordSetToWordsImpl } from "./char-util";
 
 export function fromUTF16ToString(word: Iterable<number>): string {
 	return String.fromCharCode(...word);
@@ -44,59 +45,8 @@ export function fromStringToUnicode(string: string): number[] {
  *
  * @param wordSet
  */
-export function* wordSetToWords(wordSet: readonly CharSet[]): IterableIterator<number[]> {
-	if (wordSet.length === 0) {
-		yield [];
-	} else {
-		const charsArray: number[][] = [];
-		for (const set of wordSet) {
-			const chars: number[] = [];
-			for (const { min, max } of set.ranges) {
-				for (let i = min; i <= max; i++) {
-					chars.push(i);
-				}
-			}
-			charsArray.push(chars);
-		}
-		yield* nestedIteration(charsArray);
-	}
-}
-
-function* nestedIteration<T>(arrays: T[][]): IterableIterator<T[]> {
-	const indexes: number[] = [];
-
-	for (let i = 0; i < arrays.length; i++) {
-		const array = arrays[i];
-		if (array.length === 0) {
-			return;
-		}
-		indexes[i] = 0;
-	}
-
-	function hasNext(): boolean {
-		let i = arrays.length - 1;
-		while (true) {
-			if (i < 0) {
-				return false;
-			}
-			const index = ++indexes[i];
-			if (index >= arrays[i].length) {
-				indexes[i] = 0;
-				i--;
-			} else {
-				break;
-			}
-		}
-		return true;
-	}
-
-	do {
-		const res: T[] = [];
-		for (let i = 0; i < indexes.length; i++) {
-			res[i] = arrays[i][indexes[i]];
-		}
-		yield res;
-	} while (hasNext());
+export function wordSetToWords(wordSet: readonly CharSet[]): IterableIterator<number[]> {
+	return wordSetToWordsImpl(wordSet);
 }
 
 const READABILITY_ASCII_PRIORITY: readonly CharRange[] = [

--- a/tests/helper/fa.ts
+++ b/tests/helper/fa.ts
@@ -1,7 +1,7 @@
 import { DFA } from "../../src/dfa";
 import { NFA, ReadonlyNFA } from "../../src/nfa";
 import { Parser, Literal } from "../../src/js";
-import { faIterateStates } from "../../src/fa-iterator";
+import * as Iter from "../../src/iter";
 
 export function literalToString(literal: Literal): string {
 	return `/${literal.source}/${literal.flags}`;
@@ -38,7 +38,7 @@ export function removeIndentation(expected: string): string {
 }
 
 export function reachableFinalStates(nfa: ReadonlyNFA): number {
-	const iter = faIterateStates({
+	const iter = Iter.iterateStates({
 		initial: nfa.nodes.initial,
 		getOut(node) {
 			return node.out.keys();


### PR DESCRIPTION
This adds the `src/iter` directory for all functions that produce or consume `FAIterator`s (= graph iterators). The algorithms implemented by those functions are agnostic to the actual representation/type of graph they operate on (this makes them ideal for holding shared logic between FA classes).

This should make it easier to add to and use those functions. It also cleans up the project structure since those functions are independent of the rest (except for util and character functions/classes and shared interfaces). 

I also got rid of the inconsistently used `fa` prefix.

---

This is a purely internal change. No public APIs were changed.