### PR TITLE
Made the `source` property of nodes optional

### DIFF
--- a/src/dfa.ts
+++ b/src/dfa.ts
@@ -11,7 +11,7 @@ import {
 import { CharMap, ReadonlyCharMap } from "./char-map";
 import { CharRange, CharSet } from "./char-set";
 import { invertCharMap, getBaseSets, decomposeIntoBaseSets, rangesToString, wordSetsToWords } from "./char-util";
-import { Simple, Expression } from "./ast";
+import { NoParent, Expression } from "./ast";
 import * as Iter from "./iter";
 
 const DEFAULT_MAX_NODES = 10_000;
@@ -101,7 +101,7 @@ export class DFA implements ReadonlyDFA {
 		return Iter.toString(this.transitionIterator(), rangesToString);
 	}
 
-	toRegex(options?: Readonly<ToRegexOptions>): Simple<Expression> {
+	toRegex(options?: Readonly<ToRegexOptions>): NoParent<Expression> {
 		return Iter.toRegex(this.transitionIterator(), options);
 	}
 

--- a/src/finite-automaton.ts
+++ b/src/finite-automaton.ts
@@ -1,4 +1,4 @@
-import type { Expression, Simple } from "./ast";
+import type { Expression, NoParent } from "./ast";
 import type { CharSet } from "./char-set";
 
 export interface FiniteAutomaton {
@@ -48,7 +48,7 @@ export interface FiniteAutomaton {
 	 * Returns a string representation of this FA.
 	 */
 	toString(): string;
-	toRegex(options?: Readonly<ToRegexOptions>): Simple<Expression>;
+	toRegex(options?: Readonly<ToRegexOptions>): NoParent<Expression>;
 }
 
 export interface ToRegexOptions {

--- a/src/js/js-assertion.ts
+++ b/src/js/js-assertion.ts
@@ -1,4 +1,4 @@
-import { Element, Assertion, Simple } from "../ast";
+import { Element, Assertion, NoParent } from "../ast";
 import { CharSet } from "../char-set";
 import { assertNever } from "../util";
 import { LINE_TERMINATOR, UNICODE_MAXIMUM, UTF16_MAXIMUM, WORD, WORD_IU } from "./js-util";
@@ -13,7 +13,7 @@ export interface TextBoundaryAssertion {
 	kind: "end" | "start";
 }
 
-export function createAssertion(assertion: Readonly<BoundaryAssertion>, flags: Readonly<Flags>): Simple<Element> {
+export function createAssertion(assertion: Readonly<BoundaryAssertion>, flags: Readonly<Flags>): NoParent<Element> {
 	const maximum = flags.unicode ? UNICODE_MAXIMUM : UTF16_MAXIMUM;
 
 	switch (assertion.kind) {
@@ -62,7 +62,7 @@ export function createAssertion(assertion: Readonly<BoundaryAssertion>, flags: R
 	}
 }
 
-function newAssertion(negate: boolean, kind: "ahead" | "behind", characters: CharSet): Simple<Assertion> {
+function newAssertion(negate: boolean, kind: "ahead" | "behind", characters: CharSet): NoParent<Assertion> {
 	return {
 		type: "Assertion",
 		negate,

--- a/src/js/parser.ts
+++ b/src/js/parser.ts
@@ -9,7 +9,8 @@ import {
 	SourceLocation,
 	Quantifier,
 	CharacterClass,
-	desimplify,
+	setSource,
+	setParent,
 } from "../ast";
 import { RegExpParser, AST } from "regexpp";
 import { assertNever } from "../util";
@@ -206,11 +207,11 @@ export class Parser implements Literal {
 				type: "Concatenation",
 				parent,
 				elements,
-				source: getSource(parent.source),
+				source: getSource(parent.source!),
 			};
 			parent.alternatives.push(concat);
 
-			this.addEmptyCharacterClass(concat.source, concat, context);
+			this.addEmptyCharacterClass(concat.source!, concat, context);
 		}
 	}
 
@@ -340,8 +341,9 @@ export class Parser implements Literal {
 
 				// "parse" is the default
 
-				const simpleAssertion = createAssertion(element, context.flags);
-				const assertion = desimplify(simpleAssertion, parent, getSource(element));
+				const assertion = createAssertion(element, context.flags);
+				setSource(assertion, getSource(element));
+				setParent<Element>(assertion, parent);
 				parent.elements.push(assertion);
 				break;
 			}

--- a/src/nfa.ts
+++ b/src/nfa.ts
@@ -1,4 +1,4 @@
-import { Concatenation, Quantifier, Element, Simple, Expression } from "./ast";
+import { Concatenation, Quantifier, Element, NoParent, Expression } from "./ast";
 import { CharSet } from "./char-set";
 import { assertNever, cachedFunc, traverse } from "./util";
 import {
@@ -119,7 +119,7 @@ export class NFA implements ReadonlyNFA {
 		return Iter.toString(this.transitionIterator(), rangesToString);
 	}
 
-	toRegex(options?: Readonly<ToRegexOptions>): Simple<Expression> {
+	toRegex(options?: Readonly<ToRegexOptions>): NoParent<Expression> {
 		return Iter.toRegex(this.transitionIterator(), options);
 	}
 
@@ -357,30 +357,30 @@ export class NFA implements ReadonlyNFA {
 	}
 
 	static fromRegex(
-		concat: Simple<Concatenation>,
+		concat: NoParent<Concatenation>,
 		options: Readonly<NFA.Options>,
 		creationOptions?: Readonly<NFA.FromRegexOptions>
 	): NFA;
 	static fromRegex(
-		expression: Simple<Expression>,
+		expression: NoParent<Expression>,
 		options: Readonly<NFA.Options>,
 		creationOptions?: Readonly<NFA.FromRegexOptions>
 	): NFA;
 	static fromRegex(
-		alternatives: readonly Simple<Concatenation>[],
+		alternatives: readonly NoParent<Concatenation>[],
 		options: Readonly<NFA.Options>,
 		creationOptions?: Readonly<NFA.FromRegexOptions>
 	): NFA;
 	static fromRegex(
-		value: Simple<Concatenation> | Simple<Expression> | readonly Simple<Concatenation>[],
+		value: NoParent<Concatenation> | NoParent<Expression> | readonly NoParent<Concatenation>[],
 		options: Readonly<NFA.Options>,
 		creationOptions?: Readonly<NFA.FromRegexOptions>
 	): NFA {
 		let nodeList: NFA.NodeList;
 		if (Array.isArray(value)) {
-			nodeList = createNodeList(value as readonly Simple<Concatenation>[], options, creationOptions || {});
+			nodeList = createNodeList(value as readonly NoParent<Concatenation>[], options, creationOptions || {});
 		} else {
-			const node = value as Simple<Expression> | Simple<Concatenation>;
+			const node = value as NoParent<Expression> | NoParent<Concatenation>;
 			if (node.type === "Concatenation") {
 				nodeList = createNodeList([node], options, creationOptions || {});
 			} else {
@@ -771,7 +771,7 @@ interface ReadonlySubList {
 }
 
 function createNodeList(
-	expression: readonly Simple<Concatenation>[],
+	expression: readonly NoParent<Concatenation>[],
 	options: Readonly<NFA.Options>,
 	creationOptions: Readonly<NFA.FromRegexOptions>
 ): NFA.NodeList {
@@ -782,7 +782,7 @@ function createNodeList(
 
 		// All sub lists guarantee that the initial node has no incoming edges.
 
-		function handleAlternation(alternatives: readonly Simple<Concatenation>[]): SubList {
+		function handleAlternation(alternatives: readonly NoParent<Concatenation>[]): SubList {
 			if (alternatives.length === 0) {
 				return { initial: nodeList.createNode(), finals: new Set<NFA.Node>() };
 			}
@@ -795,7 +795,7 @@ function createNodeList(
 			return base;
 		}
 
-		function handleConcatenation(concatenation: Simple<Concatenation>): SubList {
+		function handleConcatenation(concatenation: NoParent<Concatenation>): SubList {
 			const elements = concatenation.elements;
 
 			const base: SubList = { initial: nodeList.createNode(), finals: new Set<NFA.Node>() };
@@ -830,7 +830,7 @@ function createNodeList(
 			return base;
 		}
 
-		function handleQuantifier(quant: Simple<Quantifier>): SubList {
+		function handleQuantifier(quant: NoParent<Quantifier>): SubList {
 			const base = handleAlternation(quant.alternatives);
 			let max = quant.max;
 			if (max >= infinityThreshold) {
@@ -840,7 +840,7 @@ function createNodeList(
 			return base;
 		}
 
-		function handleElement(element: Simple<Element>, base: SubList): void {
+		function handleElement(element: NoParent<Element>, base: SubList): void {
 			switch (element.type) {
 				case "Alternation":
 					baseAppend(nodeList, base, handleAlternation(element.alternatives));

--- a/tests/regex-stress-test.ts
+++ b/tests/regex-stress-test.ts
@@ -3,7 +3,7 @@ import { Parser } from "../src/js";
 import { PrismRegexes } from "./helper/prism-regex-data";
 import { NFA } from "../src/nfa";
 import { DFA, ReadonlyDFA } from "../src/dfa";
-import { Expression, Simple } from "../src/ast";
+import { Expression, NoParent } from "../src/ast";
 import { TooManyNodesError } from "../src/finite-automaton";
 
 /**
@@ -18,7 +18,7 @@ import { TooManyNodesError } from "../src/finite-automaton";
  */
 const CHECK_RE_LANGUAGE = false;
 
-function equalLanguage(expected: ReadonlyDFA, re: Simple<Expression>, maxCharacter: number): void {
+function equalLanguage(expected: ReadonlyDFA, re: NoParent<Expression>, maxCharacter: number): void {
 	const nfa = NFA.fromRegex(re, { maxCharacter }, { disableLookarounds: true });
 	const dfa = DFA.fromFA(nfa, { maxNodes: 100000 });
 	dfa.minimize();


### PR DESCRIPTION
This makes the `source` property of all nodes optional. This is a breaking change.

Consequently, the `NoSource` and `Simple` types are no longer necessary and have been removed. `NoParent` is now the sole remaining view for nodes. This caused the signatures of many functions to change as the usages of `Simple<T>` have been replaced with `NoParent<T>`. The `VisitNoSourceAstHandler` and `VisitSimpleAstHandler` interfaces were also removed for obvious reasons.

The `set{Source,Parent}` functions have also been adjusted and no longer return a value. The `desimplify` function has been removed.

---

The main motivations for this are AST transformations and simpler interfaces. Many functions had to support all combinations of `NoParent` and `NoSource` which is no longer necessary. AST transformations are also easier to implement with an optional source because up until now a `source` property was either required or forbidden which makes it very hard to statically type algorithms that can deal with both.