### PR TITLE
Added ENFA implementation

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,7 +9,10 @@ export default /** @type {import('rollup').RollupOptions[]} */ ([
 			file: "index.js",
 			format: "cjs",
 		},
-		plugins: [nodeResolve(), terser()],
+		plugins: [
+			nodeResolve(),
+			terser({ compress: { pure_funcs: ['debugAssert'] } }),
+		],
 	},
 ]);
 

--- a/scripts/debug.ts
+++ b/scripts/debug.ts
@@ -1,4 +1,4 @@
-import { combineTransformers, transform, NFA, DFA, Words, JS, CharSet, CharacterClass, FiniteAutomaton, Expression, NoParent, Transformers } from "../src";
+import { combineTransformers, transform, NFA, DFA, ENFA, Words, JS, CharSet, CharacterClass, FiniteAutomaton, Expression, NoParent, Transformers } from "../src";
 import { performance } from "perf_hooks";
 
 // util functions
@@ -6,6 +6,11 @@ function toNFA(literal: JS.Literal): NFA {
 	const parser = JS.Parser.fromLiteral(literal);
 	const { expression, maxCharacter } = parser.parse();
 	return NFA.fromRegex(expression, { maxCharacter }, { assertions: "disable" });
+}
+function toENFA(literal: JS.Literal): ENFA {
+	const parser = JS.Parser.fromLiteral(literal);
+	const { expression, maxCharacter } = parser.parse();
+	return ENFA.fromRegex(expression, { maxCharacter }, { assertions: "disable" });
 }
 const toDFA = (literal: JS.Literal): DFA => DFA.fromFA(toNFA(literal));
 function toCharSet(literal: JS.Literal): CharSet {

--- a/scripts/debug.ts
+++ b/scripts/debug.ts
@@ -43,3 +43,11 @@ function measure(fn: () => void, samples: number = 1, label?: string): void {
 
 // actual debug code
 // DO NOT commit changes to this file
+
+const dfa = toDFA(/a+(?:b+a+)*/)
+dfa.minimize();
+console.log(toRegExp(dfa));
+
+
+console.log(toENFA(/a*b/).toString());
+console.log(toENFA(/a*?b/).toString());

--- a/src/enfa.ts
+++ b/src/enfa.ts
@@ -1,0 +1,659 @@
+/* eslint-disable no-inner-declarations */
+import { CharSet } from "./char-set";
+import { Char } from "./core-types";
+import { FAIterator, TooManyNodesError } from "./finite-automaton";
+import { assertNever, cachedFunc, intersectSet, traverse } from "./util";
+import * as Iter from "./iter";
+import { Concatenation, Element, Expression, NoParent, Quantifier } from "./ast";
+import { rangesToString } from "./char-util";
+
+const DEFAULT_MAX_NODES = 10_000;
+
+export class ENFA {
+	readonly nodes: ENFA.NodeList;
+	readonly maxCharacter: Char;
+
+	private constructor(nodes: ENFA.NodeList, maxCharacter: Char) {
+		this.nodes = nodes;
+		this.maxCharacter = maxCharacter;
+	}
+
+	toString(): string {
+		const iter: FAIterator<ENFA.ReadonlyNode, ReadonlyMap<ENFA.ReadonlyNode, CharSet | null>> = {
+			initial: this.nodes.initial,
+			getOut: n => n.out,
+			isFinal: n => n === this.nodes.final,
+		};
+		return Iter.toString(
+			Iter.markPureOut(iter),
+			cs => {
+				if (cs === null) {
+					return "ε";
+				} else {
+					return rangesToString(cs);
+				}
+			},
+			true
+		);
+	}
+
+	static fromRegex(
+		concat: NoParent<Concatenation>,
+		options: Readonly<ENFA.Options>,
+		creationOptions?: Readonly<ENFA.FromRegexOptions>
+	): ENFA;
+	static fromRegex(
+		expression: NoParent<Expression>,
+		options: Readonly<ENFA.Options>,
+		creationOptions?: Readonly<ENFA.FromRegexOptions>
+	): ENFA;
+	static fromRegex(
+		alternatives: readonly NoParent<Concatenation>[],
+		options: Readonly<ENFA.Options>,
+		creationOptions?: Readonly<ENFA.FromRegexOptions>
+	): ENFA;
+	static fromRegex(
+		value: NoParent<Concatenation> | NoParent<Expression> | readonly NoParent<Concatenation>[],
+		options: Readonly<ENFA.Options>,
+		creationOptions?: Readonly<ENFA.FromRegexOptions>
+	): ENFA {
+		let nodeList: ENFA.NodeList;
+		if (Array.isArray(value)) {
+			nodeList = createNodeList(value as readonly NoParent<Concatenation>[], options, creationOptions || {});
+		} else {
+			const node = value as NoParent<Expression> | NoParent<Concatenation>;
+			if (node.type === "Concatenation") {
+				nodeList = createNodeList([node], options, creationOptions || {});
+			} else {
+				nodeList = createNodeList(node.alternatives, options, creationOptions || {});
+			}
+		}
+		return new ENFA(nodeList, options.maxCharacter);
+	}
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace ENFA {
+	export interface ReadonlyNode {
+		readonly list: ReadonlyNodeList;
+		readonly out: ReadonlyMap<ReadonlyNode, CharSet | null>;
+		readonly in: ReadonlyMap<ReadonlyNode, CharSet | null>;
+	}
+	export interface Node extends ReadonlyNode {
+		readonly list: NodeList;
+		readonly out: Map<Node, CharSet | null>;
+		readonly in: Map<Node, CharSet | null>;
+	}
+
+	export interface ReadonlyNodeList extends Iterable<ReadonlyNode> {
+		/**
+		 * The initial state of this list.
+		 *
+		 * The initial state is fixed an cannot be changed or removed.
+		 *
+		 * This state is not allowed to have any incoming transitions.
+		 *
+		 * The initial and final state are guaranteed to be two different states.
+		 */
+		readonly initial: ReadonlyNode;
+		/**
+		 * The final state of this list.
+		 *
+		 * The final state is fixed an cannot be changed or removed.
+		 *
+		 * This state is not allowed to have any outgoing transitions.
+		 *
+		 * The initial and final state are guaranteed to be two different states.
+		 */
+		readonly final: ReadonlyNode;
+		/**
+		 * Returns the number of nodes reachable from the initial state including the initial state.
+		 *
+		 * This may include trap states. This will not include unreachable final states.
+		 *
+		 * This operation has to traverse the whole graph and runs in _O(E + V)_.
+		 */
+		count(): number;
+	}
+	export class NodeList implements ReadonlyNodeList, Iterable<Node> {
+		private _nodeCounter: number = 0;
+		private _nodeLimit: number = Infinity;
+
+		initial: Node;
+		final: Node;
+
+		constructor() {
+			this.initial = this.createNode();
+			this.final = this.createNode();
+		}
+
+		/**
+		 * Creates a new node associated with this node list.
+		 */
+		createNode(): Node {
+			const id = this._nodeCounter++;
+			if (id > this._nodeLimit) {
+				throw new TooManyNodesError(`The ENFA is not allowed to create more than ${this._nodeLimit} nodes.`);
+			}
+
+			const node: Node & { id: number } = {
+				id, // for debugging
+				list: this,
+				out: new Map(),
+				in: new Map(),
+			};
+			return node;
+		}
+
+		/**
+		 * Adds a transition from `from` to `to` using the given non-empty set of characters.
+		 *
+		 * If two nodes are already linked, the character sets will be combined.
+		 *
+		 * @param from
+		 * @param to
+		 * @param characters
+		 */
+		linkNodes(from: Node, to: Node, characters: CharSet | null): void {
+			if (from.list !== to.list) {
+				throw new Error("You can't link nodes from different node lists.");
+			}
+			if (from.list !== this) {
+				throw new Error("Use the node list associated with the nodes to link them.");
+			}
+			if (from.out.has(to)) {
+				throw new Error("Cannot link nodes that are already linked.");
+			}
+			if (characters && characters.isEmpty) {
+				throw new Error("You can't link nodes with the empty character set.");
+			}
+
+			from.out.set(to, characters);
+			to.in.set(from, characters);
+		}
+
+		/**
+		 * Removes the transition from `from` to `to`.
+		 *
+		 * If there is no transition from `from` to `to`, an error will be thrown.
+		 *
+		 * @param from
+		 * @param to
+		 */
+		unlinkNodes(from: Node, to: Node): void {
+			if (from.list !== to.list) {
+				throw new Error("You can't link nodes from different node lists.");
+			}
+			if (from.list !== this) {
+				throw new Error("Use the node list associated with the nodes to link them.");
+			}
+
+			if (!from.out.has(to)) {
+				throw new Error("Can't unlink nodes which aren't linked.");
+			}
+
+			from.out.delete(to);
+			to.in.delete(from);
+		}
+
+		/**
+		 * All states which cannot be reached from the initial state or cannot reach (or are) a final state, will be
+		 * removed.
+		 */
+		removeUnreachable(): void {
+			const makeEmpty = (): void => {
+				this.initial.in.clear();
+				this.initial.out.clear();
+				this.final.in.clear();
+				this.final.out.clear();
+			};
+
+			if (this.final.in.size === 0 || this.initial.out.size === 0) {
+				makeEmpty();
+				return;
+			}
+
+			const reachableFromInitial = new Set<Node>();
+			traverse(this.initial, n => {
+				reachableFromInitial.add(n);
+				return n.out.keys();
+			});
+			const finalReachableFrom = new Set<Node>();
+			traverse(this.final, n => {
+				reachableFromInitial.add(n);
+				return n.in.keys();
+			});
+
+			const alive = intersectSet(reachableFromInitial, finalReachableFrom);
+
+			if (alive.size === 0) {
+				makeEmpty();
+			} else {
+				alive.forEach(n => {
+					n.out.forEach((_, to) => {
+						if (!alive.has(to)) {
+							this.unlinkNodes(n, to);
+						}
+					});
+					n.in.forEach((_, from) => {
+						if (!alive.has(from)) {
+							this.unlinkNodes(from, n);
+						}
+					});
+				});
+			}
+		}
+
+		count(): number {
+			let c = 0;
+			let hasSeenFinal = false;
+			traverse(this.initial, n => {
+				c++;
+				if (n === this.final) {
+					hasSeenFinal = true;
+				}
+				return n.out.keys();
+			});
+			if (!hasSeenFinal) {
+				c++;
+			}
+			return c;
+		}
+
+		[Symbol.iterator](): Iterator<Node> {
+			return Iter.iterateStates({
+				initial: this.initial,
+				getOut: state => state.out.keys(),
+				isFinal: state => this.final === state,
+			})[Symbol.iterator]();
+		}
+	}
+
+	/**
+	 * Options for the constraints on how a ENFA will be created.
+	 */
+	export interface CreationOptions {
+		/**
+		 * The maximum number of nodes the ENFA creation operation is allowed to create before throwing a
+		 * `TooManyNodesError`.
+		 *
+		 * If the maximum number of nodes is set to `Infinity`, the ENFA creation operation may create as many nodes as
+		 * necessary to construct the ENFA. This might cause the machine to run out of memory. I.e. some REs can only be
+		 * represented with a huge number of states (e.g `/a{123456789}/`).
+		 *
+		 * Note: This limit describes maximum number of __created__ nodes. If nodes are created and subsequently
+		 * discard, they will still count toward the limit.
+		 *
+		 * @default 10000
+		 */
+		maxNodes?: number;
+	}
+	export interface Options {
+		/**
+		 * The maximum numerical value any character can have.
+		 *
+		 * This will be the maximum of all underlying {@link CharSet}s.
+		 */
+		maxCharacter: Char;
+	}
+	export interface FromRegexOptions extends CreationOptions {
+		/**
+		 * How to handle assertions when construction the ENFA.
+		 *
+		 * - `"throw"`
+		 *
+		 *   This method will throw an error when encountering an assertion.
+		 *
+		 * - `"disable"`
+		 *
+		 *   This method will replace any assertion with an empty character class, effectively removing it.
+		 *
+		 * @default "throw"
+		 */
+		assertions?: "disable" | "throw";
+		/**
+		 * The number at which the maximum of a quantifier will be assumed to be infinity.
+		 *
+		 * Quantifiers with a large finite maximum (e.g. `a{1,10000}`) can create huge NFAs with thousands of states.
+		 * Any Quantifier with a maximum greater or equal to this threshold will be assumed to be infinite.
+		 *
+		 * @default Infinity
+		 */
+		infinityThreshold?: number;
+	}
+}
+
+/**
+ * Creates a node list that is only allowed to create a certain number of nodes during the execution of the given
+ * consumer function.
+ *
+ * After the node list is returned by this function, the limit no longer applies.
+ *
+ * @param maxNodes
+ * @param consumerFn
+ */
+function nodeListWithLimit(maxNodes: number, consumerFn: (nodeList: ENFA.NodeList) => void): ENFA.NodeList {
+	const nodeList = new ENFA.NodeList();
+	nodeList["_nodeLimit"] = maxNodes;
+	consumerFn(nodeList);
+	nodeList["_nodeLimit"] = Infinity;
+	return nodeList;
+}
+
+function createNodeList(
+	expression: readonly NoParent<Concatenation>[],
+	options: Readonly<ENFA.Options>,
+	creationOptions: Readonly<ENFA.FromRegexOptions>
+): ENFA.NodeList {
+	return nodeListWithLimit(creationOptions.maxNodes ?? DEFAULT_MAX_NODES, nodeList => {
+		const { initial, final } = Thompson.create(nodeList, expression, {
+			maxCharacter: options.maxCharacter,
+			assertions: creationOptions.assertions ?? "throw",
+			infinityThreshold: creationOptions.infinityThreshold ?? Infinity,
+			optimize: false,
+		});
+
+		nodeList.initial = initial;
+		nodeList.final = final;
+	});
+}
+
+interface SubList {
+	readonly initial: ENFA.Node;
+	readonly final: ENFA.Node;
+}
+interface ReadonlySubList {
+	readonly initial: ENFA.ReadonlyNode;
+	readonly final: ENFA.ReadonlyNode;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+namespace Thompson {
+	interface Options {
+		readonly maxCharacter: Char;
+		readonly assertions: "disable" | "throw";
+		readonly infinityThreshold: number;
+		readonly optimize: boolean;
+	}
+
+	export function create(
+		nodeList: ENFA.NodeList,
+		expression: readonly NoParent<Concatenation>[],
+		options: Options
+	): SubList {
+		const initial = nodeList.createNode();
+
+		return { initial, final: handleAlternatives(nodeList, expression, initial, options) };
+	}
+
+	// All of the below function guarantee that
+	// 1. no incoming transitions are added to the initial state.
+	// 2. the returned final state will not be the given initial state.
+	// 3. the returned final state will have no outgoing transitions.
+
+	function handleElement(
+		nodeList: ENFA.NodeList,
+		element: NoParent<Element>,
+		initial: ENFA.Node,
+		options: Options
+	): ENFA.Node {
+		switch (element.type) {
+			case "Alternation":
+				return handleAlternatives(nodeList, element.alternatives, initial, options);
+			case "Assertion":
+				return handleAssertion(nodeList, options);
+			case "CharacterClass":
+				return handleChar(nodeList, element.characters, initial, options);
+			case "Quantifier":
+				return handleQuantifier(nodeList, element, initial, options);
+			default:
+				assertNever(element);
+		}
+	}
+	function handleAlternatives(
+		nodeList: ENFA.NodeList,
+		alternatives: readonly NoParent<Concatenation>[],
+		initial: ENFA.Node,
+		options: Options
+	): ENFA.Node {
+		if (alternatives.length === 1) {
+			return handleConcat(nodeList, alternatives[0].elements, initial, options);
+		} else {
+			const final = nodeList.createNode();
+
+			for (const a of alternatives) {
+				const alternativeFinal = handleConcat(nodeList, a.elements, initial, options);
+				nodeList.linkNodes(alternativeFinal, final, null);
+			}
+
+			return final;
+		}
+	}
+	function handleChar(nodeList: ENFA.NodeList, characters: CharSet, initial: ENFA.Node, options: Options): ENFA.Node {
+		if (characters.maximum !== options.maxCharacter) {
+			throw new Error(`Expected a max character of ${options.maxCharacter} but found ${characters.maximum}.`);
+		}
+
+		const final = nodeList.createNode();
+		if (!characters.isEmpty) {
+			nodeList.linkNodes(initial, final, characters);
+		}
+		return final;
+	}
+	function handleConcat(
+		nodeList: ENFA.NodeList,
+		elements: readonly NoParent<Element>[],
+		initial: ENFA.Node,
+		options: Options
+	): ENFA.Node {
+		let final = initial;
+		for (const e of elements) {
+			final = handleElement(nodeList, e, final, options);
+		}
+		if (final === initial) {
+			final = nodeList.createNode();
+			nodeList.linkNodes(initial, final, null);
+		}
+		return final;
+	}
+	function handleQuantifier(
+		nodeList: ENFA.NodeList,
+		quant: NoParent<Quantifier>,
+		initial: ENFA.Node,
+		options: Options
+	): ENFA.Node {
+		const originalInitial = initial;
+
+		let { min, max } = quant;
+
+		if (max > options.infinityThreshold) {
+			max = Infinity;
+		}
+
+		if (min > 1) {
+			for (let i = 1; i < min; i++) {
+				initial = handleAlternatives(nodeList, quant.alternatives, initial, options);
+			}
+
+			max -= min - 1;
+			min = 1;
+		}
+
+		// min is now either 1 or 0
+
+		const lazy = quant.lazy;
+
+		if (min === 1) {
+			if (max === Infinity) {
+				// we do a plus now
+
+				const final = nodeList.createNode();
+
+				const altInitial = nodeList.createNode();
+				nodeList.linkNodes(initial, altInitial, null);
+
+				const altFinal = handleAlternatives(nodeList, quant.alternatives, altInitial, options);
+				if (lazy) {
+					nodeList.linkNodes(altFinal, final, null);
+					nodeList.linkNodes(altFinal, altInitial, null);
+				} else {
+					nodeList.linkNodes(altFinal, altInitial, null);
+					nodeList.linkNodes(altFinal, final, null);
+				}
+
+				return final;
+			} else {
+				min--;
+				max--;
+				initial = handleAlternatives(nodeList, quant.alternatives, initial, options);
+			}
+		}
+
+		// min is now 0
+
+		if (max === 0) {
+			if (initial === originalInitial) {
+				const final = nodeList.createNode();
+				nodeList.linkNodes(initial, final, null);
+				return final;
+			} else {
+				return initial;
+			}
+		} else if (max === Infinity) {
+			// we do a star now
+
+			const final = nodeList.createNode();
+			if (lazy) {
+				nodeList.linkNodes(initial, final, null);
+			}
+
+			const altInitial = nodeList.createNode();
+			nodeList.linkNodes(initial, altInitial, null);
+
+			const altFinal = handleAlternatives(nodeList, quant.alternatives, altInitial, options);
+			if (lazy) {
+				nodeList.linkNodes(altFinal, final, null);
+				nodeList.linkNodes(altFinal, altInitial, null);
+			} else {
+				nodeList.linkNodes(altFinal, altInitial, null);
+				nodeList.linkNodes(altFinal, final, null);
+			}
+
+			if (!lazy) {
+				nodeList.linkNodes(initial, final, null);
+			}
+
+			return final;
+		} else {
+			// 1 <= max < Infinity
+			// What is done here for `A{0,3}` is equivalent to `(A(A(A|)|)|)` if not lazy and `(|A(|A(|A)))` if lazy.
+
+			// TODO: do this without recursion
+			function foo(initial: ENFA.Node, count: number): ENFA.Node {
+				const final = nodeList.createNode();
+				if (lazy) {
+					nodeList.linkNodes(initial, final, null);
+				}
+
+				let inner = handleAlternatives(nodeList, quant.alternatives, initial, options);
+				if (count > 1) {
+					inner = foo(inner, count - 1);
+				}
+				nodeList.linkNodes(inner, final, null);
+
+				if (!lazy) {
+					nodeList.linkNodes(initial, final, null);
+				}
+
+				return final;
+			}
+
+			return foo(initial, max);
+		}
+	}
+	function handleAssertion(nodeList: ENFA.NodeList, options: Options): ENFA.Node {
+		if (options.assertions === "throw") {
+			throw new Error("Assertions are not supported yet.");
+		}
+		return nodeList.createNode();
+	}
+}
+
+function isEmpty(element: ReadonlySubList): boolean {
+	return element.final.in.size === 0;
+}
+function createEmpty(nodeList: ENFA.NodeList): SubList {
+	return { initial: nodeList.createNode(), final: nodeList.createNode() };
+}
+function createEmptyConcat(nodeList: ENFA.NodeList): SubList {
+	const initial = nodeList.createNode();
+	const final = nodeList.createNode();
+
+	nodeList.linkNodes(initial, final, null);
+
+	return { initial, final };
+}
+function union(nodeList: ENFA.NodeList, alternatives: SubList[]): SubList {
+	if (alternatives.length === 0) {
+		return createEmpty(nodeList);
+	} else if (alternatives.length === 1) {
+		return alternatives[0];
+	} else {
+		const initial = nodeList.createNode();
+		const final = nodeList.createNode();
+
+		for (const a of alternatives) {
+			nodeList.linkNodes(initial, a.initial, null);
+			nodeList.linkNodes(a.final, final, null);
+		}
+
+		return { initial, final };
+	}
+}
+function concat(nodeList: ENFA.NodeList, elements: SubList[]): SubList {
+	if (elements.length === 0) {
+		return createEmptyConcat(nodeList);
+	} else if (elements.length === 1) {
+		return elements[0];
+	} else {
+		const initial = elements[0].initial;
+		const final = elements[elements.length - 1].final;
+
+		for (let i = 1; i < elements.length; i++) {
+			const prev = elements[i - 1];
+			const next = elements[i];
+
+			nodeList.linkNodes(prev.final, next.initial, null);
+		}
+
+		return { initial, final };
+	}
+}
+function copy(nodeList: ENFA.NodeList, toCopy: ReadonlySubList): SubList {
+	const initial = nodeList.createNode();
+	const final = nodeList.createNode();
+
+	const translate = cachedFunc<ENFA.ReadonlyNode, ENFA.Node>(() => nodeList.createNode());
+	translate.cache.set(toCopy.initial, initial);
+	translate.cache.set(toCopy.final, final);
+
+	traverse(toCopy.initial, n => {
+		const from = translate(n);
+
+		n.out.forEach((trans, to) => {
+			nodeList.linkNodes(from, translate(to), trans);
+		});
+
+		return n.out.keys();
+	});
+
+	return { initial, final };
+}
+/*function repeat(nodeList: ENFA.NodeList, element: SubList, count: number): SubList {
+	if (count < 1) {
+		return createEmptyConcat(nodeList);
+	} else if (count === 1) {
+		return element;
+	} else {
+	}
+}*/

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from "./finite-automaton";
 export * from "./ast";
 export * from "./nfa";
 export * from "./dfa";
+export * from "./enfa";
 
 export * as Transformers from "./transformers";
 export * as JS from "./js/index";

--- a/src/iter/to-string.ts
+++ b/src/iter/to-string.ts
@@ -59,7 +59,10 @@ export function toString<S, T>(
 	return states
 		.map(state => {
 			const label = labelOf(state);
-			const out = stableIter.getOut(state).sort(([s1], [s2]) => indexOf(s1) - indexOf(s2));
+			const out = stableIter.getOut(state);
+			if (!ordered) {
+				out.sort(([s1], [s2]) => indexOf(s1) - indexOf(s2));
+			}
 
 			if (out.length === 0) {
 				return `${label} -> none`;

--- a/src/iter/to-string.ts
+++ b/src/iter/to-string.ts
@@ -1,4 +1,5 @@
 import { FAIterator } from "../finite-automaton";
+import { iterToArray } from "../util";
 import { cacheOut, iterateStates, mapOut, mapOutIter } from "./iterator";
 
 /**
@@ -28,12 +29,18 @@ import { cacheOut, iterateStates, mapOut, mapOutIter } from "./iterator";
  * [3] -> none
  * ```
  */
-export function toString<S, T>(iter: FAIterator<S, Iterable<[S, T]>>, toString: (value: T) => string = String): string {
+export function toString<S, T>(
+	iter: FAIterator<S, Iterable<[S, T]>>,
+	toString: (value: T) => string = String,
+	ordered: boolean = false
+): string {
 	const stableIter = cacheOut(
 		mapOut(iter, out => {
-			return [...out]
-				.map<[S, string]>(([k, v]) => [k, toString(v)])
-				.sort(([, a], [, b]) => a.localeCompare(b));
+			const mapped = iterToArray(out).map<[S, string]>(([k, v]) => [k, toString(v)]);
+			if (!ordered) {
+				mapped.sort(([, a], [, b]) => a.localeCompare(b));
+			}
+			return mapped;
 		})
 	);
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -164,13 +164,25 @@ export function* iterateBFS<S>(startElements: Iterable<S>, next: (element: S) =>
 
 /**
  * Traverses the given graph in any order. All elements will be visited exactly once.
- *
- * @param root
- * @param next
  */
 export function traverse<S>(root: S, next: (element: S) => Iterable<S>): void {
 	const visited = new Set<S>();
 	const toCheck: S[] = [root];
+
+	let element;
+	while ((element = toCheck.pop())) {
+		if (!visited.has(element)) {
+			visited.add(element);
+			toCheck.push(...next(element));
+		}
+	}
+}
+/**
+ * Traverses the given graph in any order. All elements will be visited exactly once.
+ */
+export function traverseMultiRoot<S>(roots: Iterable<S>, next: (element: S) => Iterable<S>): void {
+	const visited = new Set<S>();
+	const toCheck: S[] = [...roots];
 
 	let element;
 	while ((element = toCheck.pop())) {
@@ -186,6 +198,12 @@ export function assertNever(value: never, message?: string): never {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	(error as any).data = value;
 	throw error;
+}
+
+export function debugAssert(condition: boolean, message?: string): asserts condition {
+	if (!condition) {
+		throw new Error("Debug assertion failed." + (message ? "Message: " + message : ""));
+	}
 }
 
 export type UnionIterable<T> = Iterable<T> & { __unionIterable?: never };

--- a/tests/enfa.ts
+++ b/tests/enfa.ts
@@ -1,0 +1,1220 @@
+import { ENFA } from "../src/enfa";
+import { NFA } from "../src/nfa";
+import { assert } from "chai";
+import { fromStringToUnicode, fromUnicodeToString } from "../src/words";
+import { literalToString, removeIndentation, literalToENFA } from "./helper/fa";
+import { FINITE_LITERALS, NON_FINITE_LITERALS, NON_EMPTY_LITERALS, EMPTY_LITERALS } from "./helper/regexp-literals";
+import { Literal } from "../src/js";
+import { prefixes, suffixes } from "./helper/util";
+import { wordTestData, testWordTestCases } from "./helper/word-test-data";
+
+describe("ENFA", function () {
+	describe("fromRegex", function () {
+		test([
+			{
+				literal: /a*/,
+				expected: `
+					(0) -> (1) : ε
+					    -> [2] : ε
+
+					(1) -> (3) : 61
+
+					[2] -> none
+
+					(3) -> (1) : ε
+					    -> [2] : ε`,
+			},
+			{
+				literal: /a*?/,
+				expected: `
+					(0) -> [1] : ε
+					    -> (2) : ε
+
+					[1] -> none
+
+					(2) -> (3) : 61
+
+					(3) -> [1] : ε
+					    -> (2) : ε`,
+			},
+			{
+				literal: /a+/,
+				expected: `
+					(0) -> (1) : ε
+
+					(1) -> (2) : 61
+
+					(2) -> (1) : ε
+					    -> [3] : ε
+
+					[3] -> none`,
+			},
+			{
+				literal: /a+?/,
+				expected: `
+					(0) -> (1) : ε
+
+					(1) -> (2) : 61
+
+					(2) -> [3] : ε
+					    -> (1) : ε
+
+					[3] -> none`,
+			},
+			{
+				literal: /a?/,
+				expected: `
+					(0) -> (1) : 61
+					    -> [2] : ε
+
+					(1) -> [2] : ε
+
+					[2] -> none`,
+			},
+			{
+				literal: /a??/,
+				expected: `
+					(0) -> [1] : ε
+					    -> (2) : 61
+
+					[1] -> none
+
+					(2) -> [1] : ε`,
+			},
+			{
+				literal: /a{2,4}/,
+				expected: `
+					(0) -> (1) : 61
+
+					(1) -> (2) : 61
+
+					(2) -> (3) : 61
+					    -> [4] : ε
+
+					(3) -> (5) : 61
+					    -> [4] : ε
+
+					[4] -> none
+
+					(5) -> [4] : ε`,
+			},
+			{
+				literal: /a{2,4}?/,
+				expected: `
+					(0) -> (1) : 61
+
+					(1) -> (2) : 61
+
+					(2) -> [3] : ε
+					    -> (4) : 61
+
+					[3] -> none
+
+					(4) -> [3] : ε
+					    -> (5) : 61
+
+					(5) -> [3] : ε`,
+			},
+			{
+				literal: /a{3}/,
+				expected: `
+					(0) -> (1) : 61
+
+					(1) -> (2) : 61
+
+					(2) -> [3] : 61
+
+					[3] -> none`,
+			},
+			{
+				literal: /a{3}?/,
+				expected: `
+					(0) -> (1) : 61
+
+					(1) -> (2) : 61
+
+					(2) -> [3] : 61
+
+					[3] -> none`,
+			},
+			{
+				literal: /(a|b)+c/,
+				expected: `
+					(0) -> (1) : ε
+
+					(1) -> (2) : 61
+					    -> (3) : 62
+
+					(2) -> (4) : ε
+
+					(3) -> (4) : ε
+
+					(4) -> (1) : ε
+					    -> (5) : ε
+
+					(5) -> [6] : 63
+
+					[6] -> none`,
+			},
+			{
+				literal: /a*b*c*/,
+				expected: `
+					(0) -> (1) : ε
+					    -> (2) : ε
+
+					(1) -> (3) : 61
+
+					(2) -> (4) : ε
+					    -> (5) : ε
+
+					(3) -> (1) : ε
+					    -> (2) : ε
+
+					(4) -> (6) : 62
+
+					(5) -> (7) : ε
+					    -> [8] : ε
+
+					(6) -> (4) : ε
+					    -> (5) : ε
+
+					(7) -> (9) : 63
+
+					[8] -> none
+
+					(9) -> (7) : ε
+					    -> [8] : ε`,
+			},
+			{
+				literal: /a*b*?c*/,
+				expected: `
+					(0) -> (1) : ε
+					    -> (2) : ε
+
+					(1) -> (3) : 61
+
+					(2) -> (4) : ε
+					    -> (5) : ε
+
+					(3) -> (1) : ε
+					    -> (2) : ε
+
+					(4) -> (6) : ε
+					    -> [7] : ε
+
+					(5) -> (8) : 62
+
+					(6) -> (9) : 63
+
+					[7] -> none
+
+					(8) -> (4) : ε
+					    -> (5) : ε
+
+					(9) -> (6) : ε
+					    -> [7] : ε`,
+			},
+			{
+				literal: /a+b+?c+/,
+				expected: `
+					(0) -> (1) : ε
+
+					(1) -> (2) : 61
+
+					(2) -> (1) : ε
+					    -> (3) : ε
+
+					(3) -> (4) : ε
+
+					(4) -> (5) : 62
+
+					(5) -> (6) : ε
+					    -> (4) : ε
+
+					(6) -> (7) : ε
+
+					(7) -> (8) : 63
+
+					(8) -> (7) : ε
+					    -> [9] : ε
+
+					[9] -> none`,
+			},
+			{
+				literal: /(a|){3}/,
+				expected: `
+					(0) -> (1) : 61
+					    -> (2) : ε
+
+					(1) -> (3) : ε
+
+					(2) -> (3) : ε
+
+					(3) -> (4) : 61
+					    -> (5) : ε
+
+					(4) -> (6) : ε
+
+					(5) -> (6) : ε
+
+					(6) -> (7) : 61
+					    -> (8) : ε
+
+					(7) -> [9] : ε
+
+					(8) -> [9] : ε
+
+					[9] -> none`,
+			},
+			{
+				literal: /(|a){3}/,
+				expected: `
+					(0) -> (1) : ε
+					    -> (2) : 61
+
+					(1) -> (3) : ε
+
+					(2) -> (3) : ε
+
+					(3) -> (4) : ε
+					    -> (5) : 61
+
+					(4) -> (6) : ε
+
+					(5) -> (6) : ε
+
+					(6) -> (7) : ε
+					    -> (8) : 61
+
+					(7) -> [9] : ε
+
+					(8) -> [9] : ε
+
+					[9] -> none`,
+			},
+			{
+				literal: /(|a|){3}/,
+				expected: `
+					(0) -> (1) : ε
+					    -> (2) : 61
+					    -> (3) : ε
+
+					(1) -> (4) : ε
+
+					(2) -> (4) : ε
+
+					(3) -> (4) : ε
+
+					(4) -> (5) : ε
+					    -> (6) : 61
+					    -> (7) : ε
+
+					(5) -> (8) : ε
+
+					(6) -> (8) : ε
+
+					(7) -> (8) : ε
+
+					(8) -> (9) : ε
+					    -> (10) : 61
+					    -> (11) : ε
+
+					(9) -> [12] : ε
+
+					(10) -> [12] : ε
+
+					(11) -> [12] : ε
+
+					[12] -> none`,
+			},
+			{
+				literal: /(ab){0,3}/,
+				expected: `
+					(0) -> (1) : 61
+					    -> [2] : ε
+
+					(1) -> (3) : 62
+
+					[2] -> none
+
+					(3) -> (4) : 61
+					    -> [2] : ε
+
+					(4) -> (5) : 62
+
+					(5) -> (6) : 61
+					    -> [2] : ε
+
+					(6) -> (7) : 62
+
+					(7) -> [2] : ε`,
+			},
+			{
+				literal: /a+|/,
+				expected: `
+					(0) -> (1) : ε
+					    -> (2) : ε
+
+					(1) -> (3) : 61
+
+					(2) -> [4] : ε
+
+					(3) -> (1) : ε
+					    -> (5) : ε
+
+					[4] -> none
+
+					(5) -> [4] : ε`,
+			},
+			{
+				literal: /(a|)+/,
+				expected: `
+					(0) -> (1) : ε
+
+					(1) -> (2) : 61
+					    -> (3) : ε
+
+					(2) -> (4) : ε
+
+					(3) -> (4) : ε
+
+					(4) -> (1) : ε
+					    -> [5] : ε
+
+					[5] -> none`,
+			},
+			{
+				literal: /(a+)+/,
+				expected: `
+					(0) -> (1) : ε
+
+					(1) -> (2) : ε
+
+					(2) -> (3) : 61
+
+					(3) -> (2) : ε
+					    -> (4) : ε
+
+					(4) -> (1) : ε
+					    -> [5] : ε
+
+					[5] -> none`,
+			},
+			{
+				literal: /((a*)+)?/,
+				expected: `
+					(0) -> (1) : ε
+					    -> [2] : ε
+
+					(1) -> (3) : ε
+					    -> (4) : ε
+
+					[2] -> none
+
+					(3) -> (5) : 61
+
+					(4) -> (1) : ε
+					    -> (6) : ε
+
+					(5) -> (3) : ε
+					    -> (4) : ε
+
+					(6) -> [2] : ε`,
+			},
+			{
+				literal: /(a|b)?c/,
+				expected: `
+					(0) -> (1) : 61
+					    -> (2) : 62
+					    -> (3) : ε
+
+					(1) -> (4) : ε
+
+					(2) -> (4) : ε
+
+					(3) -> [5] : 63
+
+					(4) -> (3) : ε
+
+					[5] -> none`,
+			},
+			{
+				literal: /(a+|b+)*/,
+				expected: `
+					(0) -> (1) : ε
+					    -> [2] : ε
+
+					(1) -> (3) : ε
+					    -> (4) : ε
+
+					[2] -> none
+
+					(3) -> (5) : 61
+
+					(4) -> (6) : 62
+
+					(5) -> (3) : ε
+					    -> (7) : ε
+
+					(6) -> (4) : ε
+					    -> (8) : ε
+
+					(7) -> (9) : ε
+
+					(8) -> (9) : ε
+
+					(9) -> (1) : ε
+					    -> [2] : ε`,
+			},
+			{
+				literal: /a*|b*/,
+				expected: `
+					(0) -> (1) : ε
+					    -> (2) : ε
+					    -> (3) : ε
+					    -> (4) : ε
+
+					(1) -> (5) : 61
+
+					(2) -> [6] : ε
+
+					(3) -> (7) : 62
+
+					(4) -> [6] : ε
+
+					(5) -> (1) : ε
+					    -> (2) : ε
+
+					[6] -> none
+
+					(7) -> (3) : ε
+					    -> (4) : ε`,
+			},
+			{
+				literal: /a+|b+|c+/,
+				expected: `
+					(0) -> (1) : ε
+					    -> (2) : ε
+					    -> (3) : ε
+
+					(1) -> (4) : 61
+
+					(2) -> (5) : 62
+
+					(3) -> (6) : 63
+
+					(4) -> (1) : ε
+					    -> (7) : ε
+
+					(5) -> (2) : ε
+					    -> (8) : ε
+
+					(6) -> (3) : ε
+					    -> (9) : ε
+
+					(7) -> [10] : ε
+
+					(8) -> [10] : ε
+
+					(9) -> [10] : ε
+
+					[10] -> none`,
+			},
+			{
+				literal: /[^\s\S]+/,
+				expected: `
+					(0) -> none`,
+			},
+			{
+				literal: /\d+(?:\.\d+)?(?:e[+-]?\d+)?/i,
+				expected: `
+					(0) -> (1) : ε
+
+					(1) -> (2) : 30..39
+
+					(2) -> (1) : ε
+					    -> (3) : ε
+
+					(3) -> (4) : 2e
+					    -> (5) : ε
+
+					(4) -> (6) : ε
+
+					(5) -> (7) : 45, 65
+					    -> [8] : ε
+
+					(6) -> (9) : 30..39
+
+					(7) -> (10) : 2b, 2d
+					    -> (11) : ε
+
+					[8] -> none
+
+					(9) -> (6) : ε
+					    -> (12) : ε
+
+					(10) -> (11) : ε
+
+					(11) -> (13) : ε
+
+					(12) -> (5) : ε
+
+					(13) -> (14) : 30..39
+
+					(14) -> (13) : ε
+					     -> (15) : ε
+
+					(15) -> [8] : ε`,
+			},
+		]);
+
+		interface TestCase {
+			literal: Literal;
+			expected: string;
+		}
+
+		function test(cases: TestCase[]): void {
+			for (const { literal, expected } of cases) {
+				it(literalToString(literal), function () {
+					const enfa = literalToENFA(literal);
+					assert.strictEqual(enfa.toString(), removeIndentation(expected));
+				});
+			}
+		}
+	});
+
+	describe("fromWords", function () {
+		test([
+			{
+				words: [],
+				expected: `
+					(0) -> none`,
+			},
+			{
+				words: [],
+			},
+			{
+				words: "",
+				expected: `
+					(0) -> [1] : ε
+
+					[1] -> none`,
+			},
+			{
+				words: "",
+			},
+			{
+				words: "foo bar foo bar baz food",
+				expected: `
+					(0) -> (1) : 66
+					    -> (2) : 62
+
+					(1) -> (3) : 6f
+
+					(2) -> (4) : 61
+
+					(3) -> (5) : 6f
+
+					(4) -> (6) : 72
+					    -> (7) : 7a
+
+					(5) -> [8] : ε
+					    -> (9) : 64
+
+					(6) -> [8] : ε
+
+					(7) -> [8] : ε
+
+					[8] -> none
+
+					(9) -> [8] : ε`,
+			},
+			{
+				words: "foo bar foo bar baz food",
+			},
+			{
+				// the space at the beginning will include the empty word
+				words: " a b c d e f g",
+			},
+			{
+				// the space at the beginning will include the empty word
+				words: "a b ab ba aa bb aaa aab aba abb baa bab bba bbb",
+			},
+		]);
+
+		interface TestCase {
+			words: Iterable<string> | string;
+			expected?: string;
+		}
+
+		function test(cases: TestCase[]): void {
+			for (const { words, expected } of cases) {
+				const persistentWords = typeof words === "string" ? words.split(/\s+/g) : [...words];
+				const title = persistentWords.map(w => JSON.stringify(w)).join(", ");
+				const chars = persistentWords.map(w => fromStringToUnicode(w));
+				it(title, function () {
+					const enfa = ENFA.fromWords(chars, { maxCharacter: 0x10ffff });
+					if (expected === undefined) {
+						const unique = [...new Set<string>(persistentWords)];
+						assert.sameMembers(getWords(enfa), unique);
+					} else {
+						assert.strictEqual(enfa.toString(), removeIndentation(expected));
+					}
+				});
+			}
+		}
+	});
+
+	describe("test", function () {
+		for (const testCase of wordTestData) {
+			it(literalToString(testCase.literal), function () {
+				const enfa = literalToENFA(testCase.literal);
+				testWordTestCases(enfa, testCase);
+			});
+		}
+	});
+
+	//	describe("union", function () {
+	//		test([
+	//			{
+	//				literal: /a/,
+	//				other: /b/,
+	//				expected: `
+	//					(0) -> [1] : 61..62
+	//
+	//					[1] -> none`,
+	//			},
+	//			{
+	//				literal: /ab|ba/,
+	//				other: /aa|bb/,
+	//				expected: `
+	//					(0) -> (1) : 61..62
+	//
+	//					(1) -> [2] : 61..62
+	//
+	//					[2] -> none`,
+	//			},
+	//			{
+	//				literal: /a/,
+	//				other: /()/,
+	//				expected: `
+	//					[0] -> [1] : 61
+	//
+	//					[1] -> none`,
+	//			},
+	//			{
+	//				literal: /a/,
+	//				other: /b*/,
+	//				expected: `
+	//					[0] -> [1] : 61
+	//					    -> [2] : 62
+	//
+	//					[1] -> none
+	//
+	//					[2] -> [2] : 62`,
+	//			},
+	//			{
+	//				literal: /a+/,
+	//				other: /b+/,
+	//				expected: `
+	//					(0) -> [1] : 61
+	//					    -> [2] : 62
+	//
+	//					[1] -> [1] : 61
+	//
+	//					[2] -> [2] : 62`,
+	//			},
+	//			{
+	//				literal: /a+/,
+	//				other: /()/,
+	//				expected: `
+	//					[0] -> [1] : 61
+	//
+	//					[1] -> [1] : 61`,
+	//			},
+	//			{
+	//				literal: /a|b|c{2}/,
+	//				other: /a{2}|b{2}|c/,
+	//				expected: `
+	//					(0) -> (1) : 61
+	//					    -> [2] : 61..63
+	//					    -> (3) : 62
+	//					    -> (4) : 63
+	//
+	//					(1) -> [2] : 61
+	//
+	//					[2] -> none
+	//
+	//					(3) -> [2] : 62
+	//
+	//					(4) -> [2] : 63`,
+	//			},
+	//		]);
+	//
+	//		interface TestCase {
+	//			literal: Literal;
+	//			other: Literal;
+	//			expected: string;
+	//		}
+	//
+	//		function test(cases: TestCase[]): void {
+	//			for (const { literal, other, expected } of cases) {
+	//				it(`${literalToString(literal)} ∪ ${literalToString(other)}`, function () {
+	//					const enfa = literalToENFA(literal);
+	//					const enfaOther = literalToENFA(other);
+	//					enfa.union(enfaOther);
+	//					const actual = enfa.toString();
+	//					assert.strictEqual(actual, removeIndentation(expected), "Actual:\n" + actual + "\n");
+	//				});
+	//			}
+	//		}
+	//	});
+
+	describe("append", function () {
+		test([
+			{
+				left: /foo/,
+				right: /bar/,
+				expected: `
+					(0) -> (1) : 66
+
+					(1) -> (2) : 6f
+
+					(2) -> (3) : 6f
+
+					(3) -> (4) : ε
+
+					(4) -> (5) : 62
+
+					(5) -> (6) : 61
+
+					(6) -> [7] : 72
+
+					[7] -> none`,
+			},
+			{
+				left: /a*/,
+				right: /b*/,
+				expected: `
+					(0) -> (1) : ε
+					    -> (2) : ε
+
+					(1) -> (3) : 61
+
+					(2) -> (4) : ε
+
+					(3) -> (1) : ε
+					    -> (2) : ε
+
+					(4) -> (5) : ε
+					    -> [6] : ε
+
+					(5) -> (7) : 62
+
+					[6] -> none
+
+					(7) -> (5) : ε
+					    -> [6] : ε`,
+			},
+			{
+				left: /a*/,
+				right: /b+/,
+				expected: `
+					(0) -> (1) : ε
+					    -> (2) : ε
+
+					(1) -> (3) : 61
+
+					(2) -> (4) : ε
+
+					(3) -> (1) : ε
+					    -> (2) : ε
+
+					(4) -> (5) : ε
+
+					(5) -> (6) : 62
+
+					(6) -> (5) : ε
+					    -> [7] : ε
+
+					[7] -> none`,
+			},
+		]);
+
+		interface TestCase {
+			left: Literal;
+			right: Literal;
+			expected: string;
+		}
+
+		function test(cases: TestCase[]): void {
+			for (const { left, right, expected } of cases) {
+				it(`${literalToString(left)} * ${literalToString(right)}`, function () {
+					const enfaLeft = literalToENFA(left);
+					const enfaRight = literalToENFA(right);
+					const enfaRightCopy = enfaRight.copy();
+					enfaLeft.append(enfaRight);
+
+					assert.strictEqual(enfaRight.toString(), enfaRightCopy.toString());
+
+					const actual = enfaLeft.toString();
+					assert.strictEqual(actual, removeIndentation(expected));
+				});
+			}
+		}
+	});
+
+	describe("prepend", function () {
+		test([
+			{
+				left: /foo/,
+				right: /bar/,
+				expected: `
+					(0) -> (1) : 62
+
+					(1) -> (2) : 61
+
+					(2) -> (3) : 72
+
+					(3) -> (4) : ε
+
+					(4) -> (5) : 66
+
+					(5) -> (6) : 6f
+
+					(6) -> [7] : 6f
+
+					[7] -> none`,
+			},
+			{
+				left: /a*/,
+				right: /b*/,
+				expected: `
+					(0) -> (1) : ε
+					    -> (2) : ε
+
+					(1) -> (3) : 62
+
+					(2) -> (4) : ε
+
+					(3) -> (1) : ε
+					    -> (2) : ε
+
+					(4) -> (5) : ε
+					    -> [6] : ε
+
+					(5) -> (7) : 61
+
+					[6] -> none
+
+					(7) -> (5) : ε
+					    -> [6] : ε`,
+			},
+			{
+				left: /a*/,
+				right: /b+/,
+				expected: `
+					(0) -> (1) : ε
+
+					(1) -> (2) : 62
+
+					(2) -> (1) : ε
+					    -> (3) : ε
+
+					(3) -> (4) : ε
+
+					(4) -> (5) : ε
+					    -> [6] : ε
+
+					(5) -> (7) : 61
+
+					[6] -> none
+
+					(7) -> (5) : ε
+					    -> [6] : ε`,
+			},
+		]);
+
+		interface TestCase {
+			left: Literal;
+			right: Literal;
+			expected: string;
+		}
+
+		function test(cases: TestCase[]): void {
+			for (const { left, right, expected } of cases) {
+				it(`${literalToString(right)} * ${literalToString(left)}`, function () {
+					const enfaLeft = literalToENFA(left);
+					const enfaRight = literalToENFA(right);
+					const enfaRightCopy = enfaRight.copy();
+					enfaLeft.prepend(enfaRight);
+
+					assert.strictEqual(enfaRight.toString(), enfaRightCopy.toString());
+
+					const actual = enfaLeft.toString();
+					assert.strictEqual(actual, removeIndentation(expected));
+				});
+			}
+		}
+	});
+
+	describe("intersectionWordSets", function () {
+		test([
+			{
+				left: /a/,
+				right: /b/,
+			},
+			{
+				left: /a*/,
+				right: /a/,
+			},
+			{
+				left: /b*(ab+)*a/,
+				right: /a*(ba+)*/,
+			},
+			{
+				left: /a+/,
+				right: /(?:a+){2,}/,
+			},
+			{
+				left: /(?:[^>"'[\]]|"[^"]*"|'[^']*')/,
+				right: /(?:[^>"'[\]]|"[^"]*"|'[^']*'){2,}/,
+			},
+		]);
+
+		interface TestCase {
+			left: Literal;
+			right: Literal;
+		}
+
+		function toArray<T>(iter: Iterable<T>, max: number = 100): T[] {
+			const array: T[] = [];
+			let i = 0;
+			for (const item of iter) {
+				if (i++ >= max) {
+					break;
+				}
+				array.push(item);
+			}
+			return array;
+		}
+
+		function test(cases: TestCase[]): void {
+			for (const { left, right } of cases) {
+				it(`${literalToString(left)} ∩ ${literalToString(right)}`, function () {
+					const enfaLeft = literalToENFA(left);
+					const enfaRight = literalToENFA(right);
+
+					const intersect = NFA.fromIntersection(enfaLeft, enfaRight);
+
+					const expected = toArray(intersect.wordSets());
+					const actual = toArray(enfaLeft.intersectionWordSets(enfaRight));
+
+					assert.strictEqual(actual.length, expected.length, "Number of word sets");
+					for (let i = 0; i < actual.length; i++) {
+						const actualWordSet = actual[i];
+						const expectedWordSet = expected[i];
+						assert.strictEqual(
+							actualWordSet.length,
+							expectedWordSet.length,
+							`Number of characters of word set ${i}.`
+						);
+
+						for (let j = 0; j < actualWordSet.length; j++) {
+							const actualCharSet = actualWordSet[j];
+							const expectedCharSet = expectedWordSet[j];
+							assert.isTrue(actualCharSet.equals(expectedCharSet), "Char sets");
+						}
+					}
+				});
+			}
+		}
+	});
+
+	describe("isEmpty", function () {
+		it("constructed from 0 words", function () {
+			// empty language
+			assert.isTrue(ENFA.fromWords([], { maxCharacter: 0xff }).isEmpty);
+			assert.isTrue(ENFA.fromWords([], { maxCharacter: 0xffff }).isEmpty);
+
+			// language containing the empty word
+			assert.isFalse(ENFA.fromWords([[]], { maxCharacter: 0xff }).isEmpty);
+			assert.isFalse(ENFA.fromWords([[]], { maxCharacter: 0xffff }).isEmpty);
+		});
+
+		describe("true", function () {
+			for (const literal of EMPTY_LITERALS) {
+				it(`${literalToString(literal)}`, function () {
+					assert.isTrue(literalToENFA(literal).isEmpty);
+				});
+			}
+		});
+
+		describe("false", function () {
+			for (const literal of NON_EMPTY_LITERALS) {
+				it(`${literalToString(literal)}`, function () {
+					assert.isFalse(literalToENFA(literal).isEmpty);
+				});
+			}
+		});
+	});
+
+	describe("isFinite", function () {
+		describe("true", function () {
+			for (const literal of FINITE_LITERALS) {
+				it(`${literalToString(literal)}`, function () {
+					assert.isTrue(literalToENFA(literal).isFinite);
+				});
+			}
+		});
+
+		describe("false", function () {
+			for (const literal of NON_FINITE_LITERALS) {
+				it(`${literalToString(literal)}`, function () {
+					assert.isFalse(literalToENFA(literal).isFinite);
+				});
+			}
+		});
+	});
+
+	describe("empty() & all()", function () {
+		it("empty()", function () {
+			assert.isTrue(ENFA.empty({ maxCharacter: 0xff }).isEmpty);
+			assert.isTrue(ENFA.empty({ maxCharacter: 0xffff }).isEmpty);
+
+			assert.isTrue(ENFA.empty({ maxCharacter: 0xff }).isFinite);
+			assert.isTrue(ENFA.empty({ maxCharacter: 0xffff }).isFinite);
+		});
+
+		it("all()", function () {
+			assert.isFalse(ENFA.all({ maxCharacter: 0xff }).isEmpty);
+			assert.isFalse(ENFA.all({ maxCharacter: 0xffff }).isEmpty);
+
+			assert.isFalse(ENFA.all({ maxCharacter: 0xff }).isFinite);
+			assert.isFalse(ENFA.all({ maxCharacter: 0xffff }).isFinite);
+		});
+	});
+
+	describe("prefixes", function () {
+		test([
+			{
+				words: [],
+			},
+			{
+				words: [""],
+			},
+			{
+				words: ["", "a"],
+			},
+			{
+				words: ["", "a", "aa", "aaa"],
+			},
+			{
+				words: ["foobar", "foo", "bar"],
+			},
+			{
+				words: ["bet", "let", "street", "sheet", "diet"],
+			},
+			{
+				words: ["bet", "bat", "boot", "boat"],
+			},
+		]);
+
+		interface TestCase {
+			words: readonly string[];
+		}
+
+		function test(cases: TestCase[]): void {
+			for (const { words } of cases) {
+				const title = words.map(w => JSON.stringify(w)).join(", ");
+				it(`${title}`, function () {
+					const chars = words.map(w => fromStringToUnicode(w));
+					const enfa = ENFA.fromWords(chars, { maxCharacter: 0x10ffff });
+					enfa.prefixes();
+
+					const acutal = [...new Set([...enfa.words()].map(fromUnicodeToString))];
+					const expected = [...prefixes(words)];
+					assert.sameMembers(acutal, expected);
+				});
+			}
+		}
+	});
+
+	describe("suffixes", function () {
+		test([
+			{
+				words: [],
+			},
+			{
+				words: [""],
+			},
+			{
+				words: ["", "a"],
+			},
+			{
+				words: ["", "a", "aa", "aaa"],
+			},
+			{
+				words: ["foobar", "foo", "bar"],
+			},
+			{
+				words: ["bet", "let", "street", "sheet", "diet"],
+			},
+			{
+				words: ["bet", "bat", "boot", "boat"],
+			},
+		]);
+
+		interface TestCase {
+			words: readonly string[];
+		}
+
+		function test(cases: TestCase[]): void {
+			for (const { words } of cases) {
+				const title = words.map(w => JSON.stringify(w)).join(", ");
+				it(`${title}`, function () {
+					const chars = words.map(w => fromStringToUnicode(w));
+					const enfa = ENFA.fromWords(chars, { maxCharacter: 0x10ffff });
+					enfa.suffixes();
+
+					const acutal = [...new Set([...enfa.words()].map(fromUnicodeToString))];
+					const expected = [...suffixes(words)];
+					assert.sameMembers(acutal, expected);
+				});
+			}
+		}
+	});
+
+	describe("Safe creation", function () {
+		const testENFA = literalToENFA(/a{1000}/);
+
+		it(ENFA.fromFA.name, function () {
+			assert.throws(() => {
+				ENFA.fromFA(testENFA, { maxNodes: 100 });
+			});
+		});
+		it(ENFA.fromRegex.name, function () {
+			assert.throws(() => {
+				ENFA.fromRegex(testENFA.toRegex(), testENFA.options, { maxNodes: 100 });
+			});
+		});
+		it(ENFA.fromTransitionIterator.name, function () {
+			assert.throws(() => {
+				ENFA.fromTransitionIterator(testENFA.transitionIterator(), testENFA.options, { maxNodes: 100 });
+			});
+		});
+		it(ENFA.fromWords.name, function () {
+			assert.throws(() => {
+				ENFA.fromWords(testENFA.words(), testENFA.options, { maxNodes: 100 });
+			});
+		});
+	});
+});
+
+function getWords(enfa: ENFA): string[] {
+	const words = new Set<string>();
+	for (const word of enfa.words()) {
+		words.add(word.map(i => String.fromCodePoint(i)).join(""));
+	}
+	return [...words];
+}

--- a/tests/helper/fa.ts
+++ b/tests/helper/fa.ts
@@ -1,5 +1,6 @@
 import { DFA } from "../../src/dfa";
 import { NFA, ReadonlyNFA } from "../../src/nfa";
+import { ENFA } from "../../src/enfa";
 import { Parser, Literal } from "../../src/js";
 import * as Iter from "../../src/iter";
 
@@ -15,6 +16,11 @@ export function literalToDFA(literal: Literal): DFA {
 export function literalToNFA(literal: Literal): NFA {
 	const parsed = Parser.fromLiteral(literal).parse();
 	return NFA.fromRegex(parsed.expression, { maxCharacter: parsed.maxCharacter });
+}
+
+export function literalToENFA(literal: Literal): ENFA {
+	const parsed = Parser.fromLiteral(literal).parse();
+	return ENFA.fromRegex(parsed.expression, { maxCharacter: parsed.maxCharacter });
 }
 
 export function removeIndentation(expected: string): string {


### PR DESCRIPTION
This adds an ENFA implementation that can be used as an alternative to NFA.

Right now, the `fromRegex` method doesn't guarantee any specific construction.

---

I also added a new `debugAssert` function that can be used to check that specific guarantees are met. All calls to this function (and the function itself) will be removed in the build. The function is only here to check guarantees during testing.