### PR TITLE
Add support for `hasIndices` flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3197,9 +3197,9 @@
       "dev": true
     },
     "regexpp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg=="
     },
     "release-zalgo": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "unicode-13.0.0": "^0.8.0"
   },
   "dependencies": {
-    "regexpp": "^3.1.0"
+    "regexpp": "^3.2.0"
   },
   "files": [
     "index.js",

--- a/src/js/flags.ts
+++ b/src/js/flags.ts
@@ -7,6 +7,8 @@ export interface Flags {
 	/** @default false */
 	global?: boolean;
 	/** @default false */
+	hasIndices?: boolean;
+	/** @default false */
 	ignoreCase?: boolean;
 	/** @default false */
 	multiline?: boolean;

--- a/src/js/to-literal.ts
+++ b/src/js/to-literal.ts
@@ -59,6 +59,9 @@ export function toLiteral(
 	}
 
 	let flagsString = "";
+	if (flags.hasIndices) {
+		flagsString += "d";
+	}
 	if (flags.global) {
 		flagsString += "g";
 	}
@@ -426,6 +429,7 @@ function getFlags(
 	return {
 		dotAll: template?.dotAll,
 		global: template?.global,
+		hasIndices: template?.hasIndices,
 		ignoreCase: ignoreCase ?? true,
 		multiline: template?.multiline ?? getMultilineFlag(value, getCharEnv({ unicode })),
 		sticky: template?.sticky,

--- a/tests/js/to-literal.ts
+++ b/tests/js/to-literal.ts
@@ -119,7 +119,7 @@ describe("JS.toLiteral", function () {
 
 			{
 				literal: { source: /(abc)/.source, flags: "d" },
-				expected: { source: /abc/.source, flags: "d" },
+				expected: { source: /(?:abc)/.source, flags: "" },
 			},
 		]);
 	});

--- a/tests/js/to-literal.ts
+++ b/tests/js/to-literal.ts
@@ -116,6 +116,11 @@ describe("JS.toLiteral", function () {
 				literal: /[\w-]/,
 				expected: /[-\w]/i,
 			},
+
+			{
+				literal: { source: /(abc)/.source, flags: "d" },
+				expected: { source: /abc/.source, flags: "d" },
+			},
 		]);
 	});
 
@@ -297,6 +302,12 @@ describe("JS.toLiteral", function () {
 				literal: /\w/u,
 				options: { flags: { dotAll: true, multiline: true, sticky: true } },
 				expected: /\w/msuy,
+			},
+
+			{
+				literal: /(abc)/,
+				options: { flags: { hasIndices: true } },
+				expected: { source: "(?:abc)", flags: "d" },
 			},
 		]);
 	});


### PR DESCRIPTION
This adds support for the `hasIndices` (`d`) flag.

While refa's code has been updated, I'm still waiting for regexpp to support the flag. The tests of this PR will fail until then.

**References**

RegExp Match Indices for ECMAScript: [Proposal](https://github.com/tc39/proposal-regexp-match-indices)
Regexpp: mysticatea/regexpp#22